### PR TITLE
add paddingBottom argument for responsive wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Gfycat embedding tag for [hexo](https://hexo.io). Install using: `npm i -S hexo-
 
 ## Syntax
 
-`{% gfycat FunnyGfycatIdentifier fixed|responsive|js [width height] %}`
+`{% gfycat FunnyGfycatIdentifier fixed|responsive|js [width height]|[paddingBottom] %}`
 
 Wrapper types:
  - `fixed` - fixed-size iframe,
@@ -13,15 +13,28 @@ Wrapper types:
 
 `width height` are optional and applicable only with `fixed` wrapper type.
 
+`paddingBottom` is optional and applicable only with `responsive` wrapper type.
+
 When using `js` remember to include [gfycat.js](https://github.com/gfycat/gfycat.js) in your layout.
 
 ## Example:
 
-`{% gfycat CourageousDiscreteDeinonychus fixed 320 240 %}`
+1. With fixed wrapper:
+   
+   `{% gfycat CourageousDiscreteDeinonychus fixed 320 240 %}`
 
-translates to:
+   translates to:
 
-`<iframe src='https://gfycat.com/ifr/CourageousDiscreteDeinonychus' frameborder='0' scrolling='no' width='320' height='240' allowfullscreen></iframe>`
+   `<iframe src='https://gfycat.com/ifr/CourageousDiscreteDeinonychus' frameborder='0' scrolling='no' width='320' height='240' allowfullscreen></iframe>`
+
+
+2. With responsive wrapper:
+   
+   `{% gfycat MiserlyNippyCockroach responsive 54% %}`
+
+   translates to:
+
+   `<div style='position:relative;padding-bottom:54%'><iframe src='https://gfycat.com/ifr/MiserlyNippyCockroach' frameborder='0' scrolling='no' width='100%'    height='100%' style='position:absolute;top:0;left:0' allowfullscreen></iframe></div>`
 
 ## Author
 [@zbicin](https://twitter.com/zbicin)

--- a/index.js
+++ b/index.js
@@ -4,19 +4,23 @@
 * Gfycat tag
 *
 * Syntax:
-*   {% gfycat FunnyGfycatIdentifier fixed|responsive|js [width height] %}
+*   {% gfycat FunnyGfycatIdentifier fixed|responsive|js [width height]|[paddingBottom] %}
 */
 
 function gfycatTag(args, content) {
     var identifier = args[0];
     var wrapperType = args[1];
     var width = args[2];
+    var paddingBottom = args[2];
     var height = args[3];
 
     if(wrapperType === 'fixed') {
         return '<iframe src="https://gfycat.com/ifr/' + identifier + '" frameborder="0" scrolling="no" allowfullscreen width="' + width + '" height="' + height + '"></iframe>';
     } else if(wrapperType === 'responsive') {
-        return '<div style="position:relative;padding-bottom:180%"><iframe src="https://gfycat.com/ifr/' + identifier + '" frameborder="0" scrolling="no" width="100%" height="100%" style="position:absolute;top:0;left:0;" allowfullscreen></iframe></div>';
+        if(!paddingBottom) {
+            paddingBottom = "180%";
+        }
+        return '<div style="position:relative;padding-bottom:' + paddingBottom + '"><iframe src="https://gfycat.com/ifr/' + identifier + '" frameborder="0" scrolling="no" width="100%" height="100%" style="position:absolute;top:0;left:0;" allowfullscreen></iframe></div>';
     } else if (wrapperType === 'js') {
         return '<div class="gfyitem" data-id="' + identifier + '"></div>';
     } else {


### PR DESCRIPTION
The appropriate value for the padding-bottom property of the responsive wrapper depends on the GIF's size (which is usually generated from Gfycat's side). Previously it was explicitly set to 180% which for me made the object's height way too large compared to the actual GIF.

I've kept the default padding-bottom value to 180%, while adding the argument to change the value.